### PR TITLE
add the spec file for building RPM packages with Copr

### DIFF
--- a/ekosdebugger.spec
+++ b/ekosdebugger.spec
@@ -1,0 +1,47 @@
+Name: ekosdebugger
+Version: 0.0.1.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Ekos Debugger
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/knro/ekosdebugger/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: systemd
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: qt5-devel
+
+
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(zlib)
+
+%description
+Ekos Debugger is a helper application to KStars, Ekos, and INDI debugging. It can be used to troubleshoot KStars, INDI, or both.
+The generated log files can be shared with developers in order to investigate any issues with the software and help to improve it.
+
+%prep
+%setup -n ekosdebugger-master
+
+%build
+
+%cmake .
+make %{?_smp_mflags} -j4
+
+%install
+make DESTDIR=%{buildroot} install
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/*
+
+
+%changelog
+* Wed Jul 29 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 0.0.1.git-1
+- added spec for copr
+


### PR DESCRIPTION
This is a step to automate the build of RPM packages for ekosdebugger.

